### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/OwnHeroNet/50f5abe9-d9bd-4162-b426-9eab75b922ad/e3ce7f0c-fb20-40de-bb40-37df83e02f60/_apis/work/boardbadge/44d42813-6872-48e9-b38d-f12b6b0139d6)](https://dev.azure.com/OwnHeroNet/50f5abe9-d9bd-4162-b426-9eab75b922ad/_boards/board/t/e3ce7f0c-fb20-40de-bb40-37df83e02f60/Microsoft.RequirementCategory)
 
 # ![Logo](logo/Logo%20Dark%20Font.png)
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/OwnHeroNet/50f5abe9-d9bd-4162-b426-9eab75b922ad/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.